### PR TITLE
refine build with openssl 1.1.0+ (#114)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
+ifdef DISABLE_SHADOWSOCKS
+OBJS := parser.o main.o redsocks.o log.o direct.o ipcache.o autoproxy.o http-connect.o \
+        socks4.o socks5.o http-relay.o base.o base64.o md5.o http-auth.o utils.o redudp.o socks5-udp.o \
+        tcpdns.o gen/version.o
+override CFLAGS += -DDISABLE_SHADOWSOCKS
+else
 OBJS := parser.o main.o redsocks.o log.o direct.o ipcache.o autoproxy.o encrypt.o shadowsocks.o http-connect.o \
         socks4.o socks5.o http-relay.o base.o base64.o md5.o http-auth.o utils.o redudp.o socks5-udp.o shadowsocks-udp.o \
         tcpdns.o gen/version.o
+endif
 SRCS := $(OBJS:.o=.c)
 CONF := config.h
 DEPS := .depend

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ $ git apply patches/disable-ss.patch
 $ make
 ```
 
+To compile on newer systems with OpenSSL 1.1.1+ (just disable shadowsocks support, no patch need and worked with ENABLE_HTTPS_PROXY. DO NOT APPLY THE PATCH!):
+```
+$ make DISABLE_SHADOWSOCKS=true
+```
+
 Since this variant of redsocks is customized for running with Openwrt, please
 read documents here (http://wiki.openwrt.org/doc/devel/crosscompile) for how
 to cross compile.

--- a/redudp.c
+++ b/redudp.c
@@ -3,8 +3,8 @@
  *
  * This code is based on redsocks project developed by Leonid Evdokimov.
  * Licensed under the Apache License, Version 2.0 (the "License").
- * 
- * 
+ *
+ *
  * redsocks - transparent TCP-to-proxy redirector
  * Copyright (C) 2007-2011 Leonid Evdokimov <leon@darkk.net.ru>
  *
@@ -65,11 +65,15 @@ struct bound_udp4 {
 };
 
 extern udprelay_subsys socks5_udp_subsys;
+#if !defined(DISABLE_SHADOWSOCKS)
 extern udprelay_subsys shadowsocks_udp_subsys;
+#endif
 static udprelay_subsys *relay_subsystems[] =
 {
     &socks5_udp_subsys,
+    #if !defined(DISABLE_SHADOWSOCKS)
     &shadowsocks_udp_subsys,
+    #endif
 };
 /***********************************************************************
  * Helpers
@@ -263,7 +267,7 @@ void redudp_bump_timeout(redudp_client *client)
     }
 }
 
-void redudp_fwd_pkt_to_sender(redudp_client *client, void *buf, size_t len, 
+void redudp_fwd_pkt_to_sender(redudp_client *client, void *buf, size_t len,
                               struct sockaddr_in * srcaddr)
 {
     size_t sent;
@@ -541,11 +545,11 @@ static int redudp_init_instance(redudp_instance *instance)
     char buf1[RED_INET_ADDRSTRLEN], buf2[RED_INET_ADDRSTRLEN];
 
     instance->shared_buff = &shared_buff[0];
-    if (instance->relay_ss->instance_init 
+    if (instance->relay_ss->instance_init
         && instance->relay_ss->instance_init(instance)) {
         log_errno(LOG_ERR, "Failed to init UDP relay subsystem.");
         goto fail;
-    } 
+    }
 
     fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (fd == -1) {


### PR DESCRIPTION
no patch needed, just use DISABLE_SHADOWSOCKS, and backward compatibility with openssl 1.0.x when ENABLE_HTTPS_PROXY.